### PR TITLE
fix: test pod 401 with custom openapi_url

### DIFF
--- a/deploy/helm/apikeymanager/templates/tests/test-connection.yaml
+++ b/deploy/helm/apikeymanager/templates/tests/test-connection.yaml
@@ -28,5 +28,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "apikeymanager.fullname" . }}:{{ .Values.service.port }}/{{ .Values.config.openapi_url }}']
+      args: ['{{ include "apikeymanager.fullname" . }}:{{ .Values.service.port }}{{ .Values.config.openapi_url }}']
   restartPolicy: Never

--- a/deploy/helm/apikeymanager/templates/tests/test-connection.yaml
+++ b/deploy/helm/apikeymanager/templates/tests/test-connection.yaml
@@ -28,5 +28,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "apikeymanager.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "apikeymanager.fullname" . }}:{{ .Values.service.port }}/{{ .Values.config.openapi_url }}']
   restartPolicy: Never


### PR DESCRIPTION
This PR fixes an issue that caused the [test pod](https://github.com/csgroup-oss/apikey-manager/blob/7556983228ed00a7aae29e8df1dcd995cce1737b/deploy/helm/apikeymanager/templates/tests/test-connection.yaml) to end in Error.

**Issue** : When setting a value for `config.openapi_url`, for e.g. `/docs/openapi.json` instead of the default `openapi.json`, the [test pod](https://github.com/csgroup-oss/apikey-manager/blob/7556983228ed00a7aae29e8df1dcd995cce1737b/deploy/helm/apikeymanager/templates/tests/test-connection.yaml) crashes with the error 404 not found :

```Bash
Connecting to apikeymanager:8000 (10.233.49.90:8000)
wget: server returned error: HTTP/1.1 404 Not Found
```
And the pod is in error :
![image](https://github.com/user-attachments/assets/8af80c86-9dfb-4650-af23-675a8e20b46e)

**Solution** : Appending the `config.openapi_url` value to the end of the tested URL.

The pod is now able to run wget without errors :

```Bash
Connecting to apikeymanager:8000 (10.233.43.252:8000)
saving to 'openapi.json'
openapi.json         100% |********************************|  6142  0:00:00 ETA
'openapi.json' saved
```

The test is sucessfull :

```Bash
NAME: apikeymanager
LAST DEPLOYED: Mon Sep 16 14:00:08 2024
NAMESPACE: debug-nleconte
STATUS: deployed
REVISION: 1
TEST SUITE:     apikeymanager-test-connection
Last Started:   Mon Sep 16 14:00:22 2024
Last Completed: Mon Sep 16 14:00:26 2024
Phase:          Succeeded
NOTES:
1. Get the application URL by running these commands:
  https://apikeymanagernew.example.com/
```

And the pod is not in error anymore :
![image](https://github.com/user-attachments/assets/0b944f53-2001-45e6-bb6c-38402a0b6f48)
